### PR TITLE
Use split incognito mode so that downloads in incognito mode are not logged after window closes

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -24,5 +24,6 @@
   "background": {
     "scripts": ["js/background.js"],
     "persistent": true
-  }
+  },
+  "incognito": "split"
 }


### PR DESCRIPTION
Use split incognito mode so that downloads in incognito mode are not logged after window closes
